### PR TITLE
Fix binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fastMRI reproducible benchmark
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/zaccharieramzi/fastmri-reproducible-benchmark/binder)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/zaccharieramzi/fastmri-reproducible-benchmark/master)
 
 The idea of this repository is to have a way to rapidly benchmark new solutions against existing reconstruction algorithms on the fastMRI dataset single-coil track.
 The reconstruction algorithms implemented or adapted to the fastMRI dataset include to this day:


### PR DESCRIPTION
I guess you had a `binder` branch at one point but not anymore so clicking on the binder link does this:
```
Could not resolve ref for gh:zaccharieramzi/fastmri-reproducible-benchmark/binder. Double check your URL.
```

![image](https://user-images.githubusercontent.com/1680079/81668214-a4b16e80-9444-11ea-98cc-86d36fd2854e.png)
