### PR TITLE
allowed to skip test dataset test if ismrmrd not installed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,7 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        pip install pyxb==1.2.6
-        pip install pytest==5.0.0 ismrmrd
+        pip install pytest==5.0.0
         pip install .
         pip install -U --no-deps tensorflow-io==0.13.0
     - name: Test with pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 cache: pip
 install:
-  - pip install pyxb
-  - pip install pytest==5.0.0 ismrmrd
+  - pip install pytest==5.0.0
   - pip install .
   - pip install -U --no-deps tensorflow-io==0.13.0
 

--- a/fastmri_recon/tests/data/datasets/multicoil/fastmri_pyfunc_multicoil_test.py
+++ b/fastmri_recon/tests/data/datasets/multicoil/fastmri_pyfunc_multicoil_test.py
@@ -1,3 +1,9 @@
+try:
+    import ismrmrd
+except ImportError:
+    ismrmrd_not_avail = True
+else:
+    ismrmrd_not_avail = False
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -42,6 +48,7 @@ def test_train_masked_kspace_dataset_from_indexable(create_full_fastmri_test_tmp
     tf_tester.assertAllInSet(mask, [1])  # this because we set af to 1
     # TODO: implement adjoint fourier multicoil
 
+@pytest.mark.skipif(ismrmrd_not_avail, reason='ismrmrd not installed')
 @pytest.mark.parametrize('ds_kwargs, expected_kspace_shape', [
     ({}, kspace_shape),
     ({'contrast': file_contrast}, kspace_shape),

--- a/fastmri_recon/tests/data/datasets/multicoil/fastmri_pyfunc_multicoil_test.py
+++ b/fastmri_recon/tests/data/datasets/multicoil/fastmri_pyfunc_multicoil_test.py
@@ -71,6 +71,7 @@ def test_test_masked_kspace_dataset_from_indexable(create_full_fastmri_test_tmp_
     tf_tester = tf.test.TestCase()
     tf_tester.assertAllInSet(mask, [1, 0])  # this because we set af to 1
 
+@pytest.mark.skipif(ismrmrd_not_avail, reason='ismrmrd not installed')
 @pytest.mark.parametrize('ds_kwargs', [
     {},
     {'n_samples': 1},

--- a/fastmri_recon/tests/training_scripts/denoising/generic_train_test.py
+++ b/fastmri_recon/tests/training_scripts/denoising/generic_train_test.py
@@ -1,11 +1,18 @@
 import time
 
-from tf_fastmri_data import config as config_data
+try:
+    from tf_fastmri_data import config as config_data
+except ModuleNotFoundError:
+    tf_fastmri_data_not_avail = True
+else:
+    tf_fastmri_data_not_avail = False
+import pytest
 
 from fastmri_recon import config as config_output
 from fastmri_recon.models.subclassed_models.denoisers.proposed_params import get_model_specs
 
 
+@pytest.mark.skipif(tf_fastmri_data_not_avail, reason='tf-fastmri-data not installed')
 def test_train_denoiser(create_full_fastmri_test_tmp_dataset):
     config_data.FASTMRI_DATA_DIR = create_full_fastmri_test_tmp_dataset['fastmri_tmp_data_dir']
     config_data.PATHS_MAP[False][False]['train'] = 'singlecoil_train/singlecoil_train'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ runstats
 nibabel
 Pillow
 tensorflow == 2.2
-tensorflow-addons >= 0.9.1
+tensorflow-addons == 0.9.1
 click
 tfkbnufft >= 0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ tensorflow == 2.2
 tensorflow-addons >= 0.9.1
 click
 tfkbnufft >= 0.1.2
-tf-fastmri-data >= 0.0.2


### PR DESCRIPTION
This way I don't have to install `pyxb` and the CI problem should be solved.

Also removed `tf-fastmri-data` from reqs